### PR TITLE
Update meeting issue workflow to run 30 min earlier

### DIFF
--- a/.github/workflows/create-meeting.yml
+++ b/.github/workflows/create-meeting.yml
@@ -5,7 +5,7 @@ env:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '30 15 * * WED'
+    - cron: '0 15 * * WED'
 
 jobs:
   meeting-issue:


### PR DESCRIPTION
Change the scheduled cron time from `15:30` to `15:00` (UTC) on Wednesdays to trigger the meeting issue creation half an hour earlier.

Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1972