### PR TITLE
meeting-template: Start tracking F45, other updates

### DIFF
--- a/.github/workflows/create-meeting.yml
+++ b/.github/workflows/create-meeting.yml
@@ -5,7 +5,7 @@ env:
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 15 * * WED'
+    - cron: '45 14 * * WED'
 
 jobs:
   meeting-issue:

--- a/dist/actionItems.js
+++ b/dist/actionItems.js
@@ -50,7 +50,7 @@ async function GetActionItems() {
                 console.debug('action item matches' + actionItemMatches[0]);
                 // if the match is just new lines, then there were no action items
                 if (actionItemMatches[0].match(/^\s*$/)) {
-                    return `#topic there are no action items from the last meeting.`;
+                    return `#info there are no action items from the last meeting.`;
                 }
                 return actionItemMatches[0];
             }

--- a/dist/index.js
+++ b/dist/index.js
@@ -22853,7 +22853,7 @@ async function GetActionItems() {
                 console.debug(`action item matches: ${actionItems}`);
                 // if the match is just whitespace, then there were no action items
                 if (!actionItems || actionItems.match(/^\s*$/)) {
-                    return `!topic there are no action items from the last meeting.`;
+                    return `!info there are no action items from the last meeting.`;
                 }
                 return actionItems;
             }

--- a/src/actionItems.ts
+++ b/src/actionItems.ts
@@ -43,7 +43,7 @@ export async function GetActionItems(): Promise<string> {
         console.debug(`action item matches: ${actionItems}`)
         // if the match is just whitespace, then there were no action items
         if (!actionItems || actionItems.match(/^\s*$/)) {
-          return `!topic there are no action items from the last meeting.`
+          return `!info there are no action items from the last meeting.`
         }
         return actionItems
       }

--- a/static/meeting-template.md
+++ b/static/meeting-template.md
@@ -78,8 +78,8 @@ At least 5 people must vote, or 51% of the WG membership, whichever is less. Vot
 
 5. Discuss the current Fedora Release Schedule to see if any actions need to be addressed
 
-    - [ ] `!topic Review Fedora 44 Release Schedule`
-        - `!link https://fedorapeople.org/groups/schedule/f-44/f-44-key-tasks.html`
+    - [ ] `!topic Review Fedora 45 Release Schedule`
+        - `!link https://fedorapeople.org/groups/schedule/f-45/f-45-key-tasks.html`
 
 6. After the Action items are covered start the topics from the tracker
 


### PR DESCRIPTION
Start tracking the F45 release schedule in the weekly meeting.

---
When no action items are found from the previous meeting, use `!info` to keep the information within the same "Action Items" topic.

---
Move the scheduled workflow off the top of the hour and run it 45 minutes before the 15:30 UTC meeting. This gives the workflow more buffer to create the issue before the meeting starts and avoids a period of high load at the start of the hour `[1]`.

`[1]`: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule